### PR TITLE
Configure mobile bundling and CI pipeline

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,46 @@
+name: Mobile CI
+
+on:
+  push:
+    branches: ["main", "develop"]
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/mobile-ci.yml'
+  pull_request:
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/mobile-ci.yml'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared packages
+        run: npm run build:packages
+
+      - name: Bundle mobile application
+        run: npm run build --workspace ybis-mobile
+
+      - name: Run mobile tests
+        run: npm run test --workspace ybis-mobile

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -2,8 +2,15 @@ const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('path');
 
 const monorepoRoot = path.resolve(__dirname, '../..');
-const packageRoots = ['core', 'ui', 'api-client', 'workflows'].map(pkg =>
-  path.resolve(monorepoRoot, 'packages', pkg)
+const sharedPackages = [
+  { name: '@ybis/core', dir: 'core' },
+  { name: '@ybis/ui', dir: 'ui' },
+  { name: '@ybis/api-client', dir: 'api-client' },
+  { name: '@ybis/workflows', dir: 'workflows' },
+];
+
+const packageDistRoots = sharedPackages.map(pkg =>
+  path.resolve(monorepoRoot, 'packages', pkg.dir, 'dist')
 );
 
 const makeBlockList = patterns =>
@@ -27,7 +34,7 @@ const extraNodeModules = new Proxy(
 
 const config = {
   projectRoot: __dirname,
-  watchFolders: [monorepoRoot, ...packageRoots],
+  watchFolders: [monorepoRoot, ...packageDistRoots],
   resolver: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
@@ -37,10 +44,11 @@ const config = {
       '@utils': path.resolve(__dirname, 'src/utils'),
       '@types': path.resolve(__dirname, 'src/types'),
       '@assets': path.resolve(__dirname, 'src/assets'),
-      '@ybis/core': path.resolve(monorepoRoot, 'packages/core/src'),
-      '@ybis/ui': path.resolve(monorepoRoot, 'packages/ui/src'),
-      '@ybis/api-client': path.resolve(monorepoRoot, 'packages/api-client/src'),
-      '@ybis/workflows': path.resolve(monorepoRoot, 'packages/workflows/src'),
+      nanoid: require.resolve('nanoid/non-secure/index.cjs'),
+      ...sharedPackages.reduce((aliases, pkg) => {
+        aliases[pkg.name] = path.resolve(monorepoRoot, 'packages', pkg.dir, 'dist');
+        return aliases;
+      }, {}),
     },
     extraNodeModules,
     nodeModulesPaths: [path.resolve(monorepoRoot, 'node_modules')],

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,18 +3,18 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "start": "node ../../node_modules/react-native/cli.js start --config ../../react-native.config.js",
-        "android": "node ../../node_modules/react-native/cli.js run-android --config ../../react-native.config.js",
-        "ios": "node ../../node_modules/react-native/cli.js run-ios --config ../../react-native.config.js",
-        "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 node ../../node_modules/react-native/cli.js bundle --config ../../react-native.config.js --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --verbose",
+        "start": "node ../../scripts/run-react-native-cli.js start --config ../../react-native.config.js --projectRoot .",
+        "android": "node ../../scripts/run-react-native-cli.js run-android --config ../../react-native.config.js --projectRoot .",
+        "ios": "node ../../scripts/run-react-native-cli.js run-ios --config ../../react-native.config.js --projectRoot .",
+        "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 node ../../scripts/run-react-native-cli.js bundle --config ../../react-native.config.js --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle",
         "build:bundle": "node ../../scripts/mobile-bundle.js",
-        "build:lite": "node ../../node_modules/react-native/cli.js bundle --config ../../react-native.config.js --platform android --dev true --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --verbose",
+        "build:lite": "node ../../scripts/run-react-native-cli.js bundle --config ../../react-native.config.js --platform android --dev true --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle",
         "build:android": "cd android && gradlew.bat assembleRelease --info",
         "build:ios": "cd ios && xcodebuild -workspace YBISMobile.xcworkspace -scheme YBISMobile -configuration Release",
         "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx --fix",
         "test": "npx jest",
         "type-check": "npx tsc --noEmit",
-        "clean": "node ../../node_modules/react-native/cli.js clean-project-auto --config ../../react-native.config.js"
+        "clean": "node ../../scripts/run-react-native-cli.js clean-project-auto --config ../../react-native.config.js --projectRoot ."
     },
     "peerDependencies": {
         "react": "19.1.0",

--- a/apps/mobile/src/stores/chatStore.ts
+++ b/apps/mobile/src/stores/chatStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { nanoid } from 'nanoid';
+import { nanoid } from 'nanoid/non-secure';
 import { ChatMessage } from '@ybis/core';
 
 export interface Message extends ChatMessage {

--- a/apps/mobile/src/stores/notesStore.ts
+++ b/apps/mobile/src/stores/notesStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { z } from 'zod';
-import { nanoid } from 'nanoid';
+import { nanoid } from 'nanoid/non-secure';
 
 // Zod v4 schemas for notes
 export const NoteSchema = z.object({

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./apps/mobile/babel.config');

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,17 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "node",
     "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts"]

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,3 +1,5 @@
+const { bundleCommand, startCommand } = require('@react-native/community-cli-plugin');
+
 module.exports = {
   project: {
     android: {
@@ -9,4 +11,5 @@ module.exports = {
       sourceDir: './apps/mobile/ios',
     },
   },
+  commands: [bundleCommand, startCommand],
 };

--- a/scripts/mobile-bundle.js
+++ b/scripts/mobile-bundle.js
@@ -4,6 +4,8 @@ const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+const cliRunner = path.resolve(__dirname, 'run-react-native-cli.js');
+
 // Renkli çıktı için ANSI kodları
 const colors = {
   reset: '\x1b[0m',
@@ -71,7 +73,7 @@ function checkPrerequisites() {
 
   // React Native CLI kontrolü
   try {
-    execSync('npx react-native --version', { stdio: 'pipe' });
+    execSync(`node ${JSON.stringify(cliRunner)} --version`, { stdio: 'pipe', cwd: path.resolve(__dirname, '..', 'apps', 'mobile') });
     logStep('2', 'React Native CLI: Available');
     logSuccess('React Native CLI is installed');
   } catch (error) {
@@ -115,7 +117,7 @@ function showBuildInfo() {
 function runBundle() {
   logSection('RUNNING BUNDLE');
   
-  const command = `cross-env NODE_OPTIONS=${buildConfig.nodeOptions} react-native bundle --platform ${buildConfig.platform} --dev ${buildConfig.dev} --entry-file ${buildConfig.entryFile} --bundle-output ${buildConfig.bundleOutput} --verbose`;
+  const command = `cross-env NODE_OPTIONS=${buildConfig.nodeOptions} node ${JSON.stringify(cliRunner)} bundle --config ../../react-native.config.js --platform ${buildConfig.platform} --dev ${buildConfig.dev} --entry-file ${buildConfig.entryFile} --bundle-output ${buildConfig.bundleOutput}`;
   
   logStep('Command', command);
   logStep('Status', 'Starting bundle process...');

--- a/scripts/run-react-native-cli.js
+++ b/scripts/run-react-native-cli.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliBin = path.resolve(
+  projectRoot,
+  'node_modules',
+  '@react-native-community',
+  'cli',
+  'build',
+  'bin.js'
+);
+
+const args = process.argv.slice(2);
+const cwd = process.cwd();
+
+const pathOptions = new Set([
+  '--config',
+  '--entry-file',
+  '--bundle-output',
+  '--assets-dest',
+  '--projectRoot',
+  '--root',
+  '--watchFolders',
+]);
+
+const normalisedArgs = [];
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+
+  if (arg.startsWith('--')) {
+    const [flag, value] = arg.split('=');
+
+    if (value !== undefined) {
+      if (pathOptions.has(flag)) {
+        normalisedArgs.push(`${flag}=${path.resolve(cwd, value)}`);
+      } else {
+        normalisedArgs.push(arg);
+      }
+      continue;
+    }
+
+    normalisedArgs.push(flag);
+
+    if (pathOptions.has(flag) && i + 1 < args.length) {
+      normalisedArgs.push(path.resolve(cwd, args[i + 1]));
+      i += 1;
+      continue;
+    }
+
+    continue;
+  }
+
+  normalisedArgs.push(arg);
+}
+
+const nodePath = [path.resolve(projectRoot, 'node_modules'), process.env.NODE_PATH]
+  .filter(Boolean)
+  .join(path.delimiter);
+
+const result = spawnSync(process.execPath, [cliBin, ...normalisedArgs], {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  env: { ...process.env, NODE_PATH: nodePath },
+});
+
+process.exit(result.status === null ? 1 : result.status);


### PR DESCRIPTION
## Summary
- update Metro to consume built package outputs and add a non-secure nanoid alias for React Native
- introduce a reusable React Native CLI runner, root babel config, and refresh mobile npm scripts
- add a mobile CI workflow that builds shared packages before bundling and testing the app

## Testing
- npm run build:packages
- npm run build --workspace ybis-mobile *(fails: Metro cannot resolve missing-asset-registry-path for navigation assets)*
- npm run test --workspace ybis-mobile *(fails: React Native stack navigator dependencies not available in Jest)*

------
https://chatgpt.com/codex/tasks/task_e_68d01a8ca4708330ba84a07052307f50