### PR TITLE
chore: add gradle wrapper helper

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,7 @@
         "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 node ../../node_modules/react-native/cli.js bundle --config ../../react-native.config.js --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --verbose",
         "build:bundle": "node ../../scripts/mobile-bundle.js",
         "build:lite": "node ../../node_modules/react-native/cli.js bundle --config ../../react-native.config.js --platform android --dev true --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --verbose",
-        "build:android": "cd android && gradlew.bat assembleRelease --info",
+        "build:android": "node ../../scripts/run-android-gradle.js assembleRelease --info",
         "build:ios": "cd ios && xcodebuild -workspace YBISMobile.xcworkspace -scheme YBISMobile -configuration Release",
         "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx --fix",
         "test": "npx jest",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+export default [
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: {
+        console: 'readonly',
+        module: 'readonly',
+        process: 'readonly',
+        require: 'readonly',
+        __dirname: 'readonly',
+      },
+    },
+    rules: {
+      'no-unused-vars': 'error',
+      'no-undef': 'error',
+    },
+  },
+  {
+    ignores: [
+      'apps/**',
+      'backend/**',
+      'docs/**',
+      'node_modules/**',
+      'packages/**',
+      'specs/**',
+      '.*',
+    ],
+  },
+];

--- a/scripts/run-android-gradle.js
+++ b/scripts/run-android-gradle.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const androidDir = path.resolve(process.cwd(), 'android');
+const isWindows = process.platform === 'win32';
+const executable = isWindows ? 'gradlew.bat' : './gradlew';
+
+const result = spawnSync(executable, process.argv.slice(2), {
+  cwd: androidDir,
+  stdio: 'inherit',
+  shell: isWindows,
+});
+
+if (result.error) {
+  const message = result.error.code === 'ENOENT'
+    ? `Could not find ${executable} in ${androidDir}`
+    : result.error.message;
+  console.error(`Failed to run Android Gradle wrapper: ${message}`);
+  process.exit(result.status ?? 1);
+}
+
+if (result.status !== null) {
+  process.exit(result.status);
+}
+
+if (result.signal) {
+  console.error(`Gradle wrapper exited due to signal: ${result.signal}`);
+  process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- add a platform-aware Node helper that runs the Android Gradle wrapper and forwards stdio/arguments
- update the mobile build script to call the helper instead of hardcoding the Windows batch file
- add a minimal flat ESLint config so Husky can lint the scripts directory under ESLint v9

## Testing
- npm run build:android (with a stub `gradlew` script returning a non-zero exit code to verify status propagation)

------
https://chatgpt.com/codex/tasks/task_e_68d06bbeab04833098dd8de8406bce30