### PR TITLE
refactor(types): stabilize shared types and tsconfig

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run deps:check || exit 1
 npx lint-staged || exit 1
 npm run type-check || exit 1

--- a/apps/mobile/screens/Chat.tsx
+++ b/apps/mobile/screens/Chat.tsx
@@ -2,12 +2,12 @@ import React, { useCallback } from 'react';
 import { View, StyleSheet, Alert, FlatList } from 'react-native';
 import { MessageBubble } from '../src/components/chat/MessageBubble';
 import { MessageComposer } from '../src/components/chat/MessageComposer';
-import { useChatStore, Message } from '../src/stores/chatStore';
+import { useChatStore, ChatMessage } from '../src/stores/chatStore';
 
 export const Chat: React.FC = () => {
   const { messages, isLoading, sendMessage } = useChatStore();
 
-  const renderMessage = useCallback(({ item }: { item: Message }) => (
+  const renderMessage = useCallback(({ item }: { item: ChatMessage }) => (
     <MessageBubble
       message={item}
       isOwn={item.isOwn}
@@ -22,7 +22,7 @@ export const Chat: React.FC = () => {
     />
   ), []);
 
-  const keyExtractor = useCallback((item: Message) => item.id, []);
+  const keyExtractor = useCallback((item: ChatMessage) => item.id, []);
 
   const handleSendMessage = useCallback((content: string) => {
     sendMessage(content);

--- a/apps/mobile/shared/state/messages.ts
+++ b/apps/mobile/shared/state/messages.ts
@@ -1,26 +1,23 @@
 import { create } from 'zustand';
-
-interface Message {
-  id: string;
-  content: string;
-  role: 'user' | 'assistant';
-  timestamp: Date;
-}
+import type { Message } from '@ybis/core';
 
 interface MessagesState {
   messages: Message[];
-  addMessage: (message: Omit<Message, 'id' | 'timestamp'>) => void;
+  addMessage: (
+    message: Omit<Message, 'id' | 'timestamp'> &
+      Partial<Pick<Message, 'id' | 'timestamp'>>
+  ) => void;
   clearMessages: () => void;
 }
 
 export const useMessagesStore = create<MessagesState>((set) => ({
   messages: [],
-  
+
   addMessage: (message) => {
     const newMessage: Message = {
       ...message,
-      id: Date.now().toString(),
-      timestamp: new Date(),
+      id: message.id ?? Date.now().toString(),
+      timestamp: message.timestamp ?? Date.now(),
     };
     set((state) => ({ messages: [...state.messages, newMessage] }));
   },

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { Message } from '../../stores/chatStore';
+import type { ChatMessage } from '../../stores/chatStore';
 
 interface MessageBubbleProps {
-  message: Message;
+  message: ChatMessage;
   isOwn: boolean;
   onPress?: () => void;
   onLongPress?: () => void;

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { MessageBubble } from '../components/chat/MessageBubble';
 import { MessageComposer } from '../components/chat/MessageComposer';
-import { useChatStore, Message } from '../stores/chatStore';
+import { useChatStore, ChatMessage } from '../stores/chatStore';
 
 const EMPTY_STATE = {
   title: 'Start a conversation',
@@ -12,7 +12,7 @@ const EMPTY_STATE = {
 export const ChatScreen: React.FC = () => {
   const { messages, isLoading, sendMessage } = useChatStore();
 
-  const renderMessage = useCallback(({ item }: { item: Message }) => (
+  const renderMessage = useCallback(({ item }: { item: ChatMessage }) => (
     <MessageBubble
       message={item}
       isOwn={item.isOwn}
@@ -21,7 +21,7 @@ export const ChatScreen: React.FC = () => {
     />
   ), []);
 
-  const keyExtractor = useCallback((item: Message) => item.id, []);
+  const keyExtractor = useCallback((item: ChatMessage) => item.id, []);
 
   const handleSendMessage = useCallback((content: string) => {
     sendMessage(content);

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "@tsconfig/react-native/tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "esnext",
-    "lib": [
-      "es2020",
-      "es2021"
-    ],
-    "module": "esnext",
+    "target": "ESNext",
+    "lib": ["ES2020", "ES2021"],
+    "module": "ESNext",
     "moduleResolution": "node",
     "jsx": "react-native",
     "allowJs": true,
@@ -17,59 +14,32 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "incremental": true,
     "composite": true,
+    "incremental": true,
+    "types": ["jest", "react", "react-native"],
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@components/*": [
-        "./src/components/*"
-      ],
-      "@screens/*": [
-        "./src/screens/*"
-      ],
-      "@hooks/*": [
-        "./src/hooks/*"
-      ],
-      "@utils/*": [
-        "./src/utils/*"
-      ],
-      "@types/*": [
-        "./src/types/*"
-      ],
-      "@assets/*": [
-        "./src/assets/*"
-      ],
-      "@ybis/core": [
-        "../packages/core/src"
-      ],
-      "@ybis/core/*": [
-        "../packages/core/src/*"
-      ],
-      "@ybis/api-client": [
-        "../packages/api-client/src"
-      ],
-      "@ybis/api-client/*": [
-        "../packages/api-client/src/*"
-      ],
-      "@ybis/ui": [
-        "../packages/ui/src"
-      ],
-      "@ybis/ui/*": [
-        "../packages/ui/src/*"
-      ],
-      "@ybis/workflows": [
-        "../packages/workflows/src"
-      ],
-      "@ybis/workflows/*": [
-        "../packages/workflows/src/*"
-      ]
-    },
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@screens/*": ["./src/screens/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@types/*": ["./src/types/*"],
+      "@assets/*": ["./src/assets/*"],
+      "@ybis/core": ["../../packages/core/src"],
+      "@ybis/core/*": ["../../packages/core/src/*"],
+      "@ybis/api-client": ["../../packages/api-client/src"],
+      "@ybis/api-client/*": ["../../packages/api-client/src/*"],
+      "@ybis/ui": ["../../packages/ui/src"],
+      "@ybis/ui/*": ["../../packages/ui/src/*"],
+      "@ybis/workflows": ["../../packages/workflows/src"],
+      "@ybis/workflows/*": ["../../packages/workflows/src/*"]
+    }
   },
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/api-client" }
+  ],
   "include": [
     "src/**/*",
     "shared/**/*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "predev": "npm run build:packages",
         "dev:packages": "concurrently \"npm run dev --workspace @ybis/api-client\" \"npm run dev --workspace @ybis/core\" \"npm run dev --workspace @ybis/ui\" \"npm run dev --workspace @ybis/workflows\"",
         "prepare": "husky",
-        "type-check": "npm run type-check --workspaces --if-present",
+        "type-check": "tsc -b",
         "start": "npx react-native start --config ./react-native.config.js --projectRoot apps/mobile"
     },
     "devDependencies": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -2,11 +2,20 @@
   "name": "@ybis/api-client",
   "version": "1.0.0",
   "description": "YBIS API Client",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "dev": "tsc -b --watch",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,19 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "outDir": "dist",
+    "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "emitDeclarationOnly": false,
+    "composite": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,11 +2,20 @@
   "name": "@ybis/core",
   "version": "1.0.0",
   "description": "YBIS Core utilities and types",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "dev": "tsc -b --watch",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // Export types
-export type * from './types';
+export * from './types';
 
 // Export schemas and functions
 export * from './schemas';

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -68,19 +68,21 @@ export const ToolUsageSchema = z.object({
   executedAt: z.string().datetime().optional(),
 });
 
-export const ChatMessageMetadataSchema = z.object({
-  intent: z.string().optional(),
-  planId: z.string().optional(),
-  requiresConfirmation: z.boolean().optional(),
-  cards: z.array(MessageCardSchema).optional(),
-  tools: z.array(ToolUsageSchema).optional(),
-});
+export const ChatMessageMetadataSchema = z
+  .object({
+    intent: z.string().optional(),
+    planId: z.string().optional(),
+    requiresConfirmation: z.boolean().optional(),
+    cards: z.array(MessageCardSchema).optional(),
+    tools: z.array(ToolUsageSchema).optional(),
+  })
+  .catchall(z.unknown());
 
 export const ChatMessageSchema = z.object({
   id: z.string(),
   content: z.string().min(1).max(10000),
-  role: z.enum(['user', 'assistant']),
-  timestamp: z.string().datetime(),
+  role: z.enum(['user', 'assistant', 'system']),
+  timestamp: z.number().nonnegative(),
   metadata: ChatMessageMetadataSchema.optional(),
 });
 

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,0 +1,40 @@
+export type MessageRole = 'user' | 'assistant' | 'system';
+
+export interface MessageMetadata extends Record<string, unknown> {
+  intent?: string;
+  planId?: string;
+  requiresConfirmation?: boolean;
+  cards?: MessageCard[];
+  tools?: ToolUsage[];
+}
+
+export interface CardAction {
+  id: string;
+  label: string;
+  type: 'primary' | 'secondary' | 'danger';
+  action: string;
+}
+
+export interface MessageCard {
+  kind: 'event' | 'task' | 'note' | 'email' | 'file';
+  payload: unknown;
+  actions?: CardAction[];
+}
+
+export interface ToolUsage {
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  executedAt?: string;
+}
+
+export interface Message {
+  id: string;
+  role: MessageRole;
+  content: string;
+  timestamp: number;
+  metadata?: MessageMetadata;
+}
+
+export type ChatMessage = Message;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -23,43 +23,7 @@ export interface NotificationPreferences {
   marketing: boolean;
 }
 
-// Chat related types
-export interface ChatMessage {
-  id: string;
-  content: string;
-  role: 'user' | 'assistant';
-  timestamp: string;
-  metadata?: ChatMessageMetadata;
-}
-
-export interface ChatMessageMetadata {
-  intent?: string;
-  planId?: string;
-  requiresConfirmation?: boolean;
-  cards?: MessageCard[];
-  tools?: ToolUsage[];
-}
-
-export interface MessageCard {
-  kind: 'event' | 'task' | 'note' | 'email' | 'file';
-  payload: any;
-  actions?: CardAction[];
-}
-
-export interface CardAction {
-  id: string;
-  label: string;
-  type: 'primary' | 'secondary' | 'danger';
-  action: string;
-}
-
-export interface ToolUsage {
-  toolName: string;
-  input: any;
-  output?: any;
-  status: 'pending' | 'running' | 'completed' | 'failed';
-  executedAt?: string;
-}
+export * from './chat';
 
 // Task related types
 export interface Task {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,19 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "outDir": "dist",
+    "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "emitDeclarationOnly": false,
+    "composite": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+  "include": ["src"]
 }
-

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,11 +2,20 @@
   "name": "@ybis/ui",
   "version": "1.0.0",
   "description": "YBIS UI Components",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "dev": "tsc -b --watch",
     "test": "jest"
   },
   "dependencies": {},

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "jsx": "react-native"
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-native",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"]

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -2,11 +2,20 @@
   "name": "@ybis/workflows",
   "version": "1.0.0",
   "description": "YBIS Workflow Engine",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "dev": "tsc -b --watch",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/workflows/tsconfig.json
+++ b/packages/workflows/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts"]
 }
-

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,12 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -16,4 +15,3 @@
     "resolveJsonModule": true
   }
 }
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/core" },
+    { "path": "./packages/api-client" },
+    { "path": "./apps/mobile" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add shared chat message contracts in `@ybis/core` and update schema exports
- align mobile chat/task stores with the shared types and stricter typing
- standardise TypeScript project references and package builds for workspace modules

## Testing
- `npm run type-check`
- `npm test -- --passWithNoTests` *(fails: existing Jest/react-native configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d2aeb8d7688330aafd92332ff6d03d